### PR TITLE
fix both latitude and longitudes to 4 decimals to get a minimum ~10m accuracy

### DIFF
--- a/src/components/FormComponents/MapSelect.jsx
+++ b/src/components/FormComponents/MapSelect.jsx
@@ -96,7 +96,7 @@ const MapSelect = ({ updateMap, mapData = {}, disabled, record }) => {
   }
 
   function limitDecimals(x) {
-    return Number.parseFloat(x).toPrecision(4);
+    return Number(Number.parseFloat(x).toFixed(4));
   }
 
   // update the polygon property using an event


### PR DESCRIPTION
cherry pick Jessy's commit to fix decimal place bug when drawing polygons on the map